### PR TITLE
add dataEventName parameter

### DIFF
--- a/doc/api/nodejs.md
+++ b/doc/api/nodejs.md
@@ -223,7 +223,7 @@ emitter.publish();
 
 ### Stream Handlers ###
 
-### <a id="rxnodefromstreamstream-finisheventname"></a>`RxNode.fromStream(stream, finishEventName)`
+### <a id="rxnodefromstreamstream-finisheventname"></a>`RxNode.fromStream(stream, finishEventName, dataEventName)`
 <a href="#rxnodefromstreamstream-finisheventname">#</a> [&#x24C8;](https://github.com/Reactive-Extensions/RxJS/blob/master/index.js#L96-L124 "View in source")
 
 Converts a flowing stream to an Observable sequence.
@@ -231,6 +231,7 @@ Converts a flowing stream to an Observable sequence.
 #### Arguments
 1. `stream` *(Stream)*: A stream to convert to a observable sequence.
 2. `[finishEventName]` *(String)*: Event that notifies about closed stream. ("end" by default)
+3. `[dataEventName]` *(String)*: Event that notifies about incoming data. ("data" by default)
 
 #### Returns
 *(Observable)*: An observable sequence which fires on each 'data' event as well as handling 'error' and finish events like `end` or `finish`.
@@ -252,13 +253,14 @@ var subscription = RxNode.fromStream(process.stdin, 'end')
 
 * * *
 
-### <a id="rxnodefromreadablestreamstream"></a>`RxNode.fromReadableStream(stream)`
+### <a id="rxnodefromreadablestreamstream"></a>`RxNode.fromReadableStream(stream, dataEventName)`
 <a href="#rxnodefromreadablestreamstream">#</a> [&#x24C8;](https://github.com/Reactive-Extensions/RxJS/blob/master/index.js#L131-L133 "View in source")
 
 Converts a flowing readable stream to an Observable sequence.
 
 #### Arguments
 1. `stream` *(Stream)*: A stream to convert to a observable sequence.
+2. `[dataEventName]` *(String)*: Event that notifies about incoming data. ("data" by default)
 
 #### Returns
 *(Observable)*: An observable sequence which fires on each 'data' event as well as handling 'error' and 'end' events.
@@ -272,6 +274,23 @@ var subscription = RxNode.fromReadableStream(process.stdin)
 
 // => r<Buffer 72>
 // => x<Buffer 78>
+```
+
+```js
+var readline = require('readline');
+var fs = require('fs');
+var RxNode = require('rx-node');
+
+var rl = readline.createInterface({
+  input: fs.createReadStream('sample.txt')
+});
+
+var subscription = RxNode.fromReadableStream(rl, 'line')
+    .subscribe(function (x) { console.log(x); });
+
+// Prints contents of 'sample.txt' line by line:
+// => rx
+// => supports 'readline'
 ```
 
 ### Location

--- a/index.js
+++ b/index.js
@@ -46,12 +46,14 @@ module.exports = {
    * Converts a flowing stream to an Observable sequence.
    * @param {Stream} stream A stream to convert to a observable sequence.
    * @param {String} [finishEventName] Event that notifies about closed stream. ("end" by default)
+   * @param {String} [dataEventName] Event that notifies about incoming data. ("data" by default)
    * @returns {Observable} An observable sequence which fires on each 'data' event as well as handling 'error' and finish events like `end` or `finish`.
    */
-  fromStream: function (stream, finishEventName) {
+  fromStream: function (stream, finishEventName, dataEventName) {
     stream.pause();
 
     finishEventName || (finishEventName = 'end');
+    dataEventName || (dataEventName = 'data');
 
     return Observable.create(function (observer) {
       function dataHandler (data) {
@@ -66,14 +68,14 @@ module.exports = {
         observer.onCompleted();
       }
 
-      stream.addListener('data', dataHandler);
+      stream.addListener(dataEventName, dataHandler);
       stream.addListener('error', errorHandler);
       stream.addListener(finishEventName, endHandler);
 
       stream.resume();
 
       return function () {
-        stream.removeListener('data', dataHandler);
+        stream.removeListener(dataEventName, dataHandler);
         stream.removeListener('error', errorHandler);
         stream.removeListener(finishEventName, endHandler);
       };
@@ -83,10 +85,11 @@ module.exports = {
   /**
    * Converts a flowing readable stream to an Observable sequence.
    * @param {Stream} stream A stream to convert to a observable sequence.
+   * @param {String} [dataEventName] Event that notifies about incoming data. ("data" by default)
    * @returns {Observable} An observable sequence which fires on each 'data' event as well as handling 'error' and 'end' events.
    */
-  fromReadableStream: function (stream) {
-    return this.fromStream(stream, 'end');
+  fromReadableStream: function (stream, dataEventName) {
+    return this.fromStream(stream, 'end', dataEventName);
   },
 
   /**
@@ -101,10 +104,11 @@ module.exports = {
   /**
    * Converts a flowing transform stream to an Observable sequence.
    * @param {Stream} stream A stream to convert to a observable sequence.
+   * @param {String} [dataEventName] Event that notifies about incoming data. ("data" by default)
    * @returns {Observable} An observable sequence which fires on each 'data' event as well as handling 'error' and 'finish' events.
    */
-  fromTransformStream: function (stream) {
-    return this.fromStream(stream, 'finish');
+  fromTransformStream: function (stream, dataEventName) {
+    return this.fromStream(stream, 'finish', dataEventName);
   },
 
   /**


### PR DESCRIPTION
Since Node.js 0.12 we are able to use 'readline' package bundled with Node.js. It provides wrapper for `readableStream` which adds new `'line'` event. It works in a similar way to the `'data'` event but instead of returning buffer with bytes chunk, String of characters is returned. This pull request adds optional 'dataEventName' parameter which allows to use `RxNode` with 'readline' package.

See also:
https://nodejs.org/api/readline.html#readline_example_read_file_stream_line_by_line
